### PR TITLE
Fix Compiler Warning

### DIFF
--- a/Classes/GAScriptBlockObject.m
+++ b/Classes/GAScriptBlockObject.m
@@ -27,6 +27,7 @@
  */
 
 #import "GAScriptBlockObject.h"
+#import "GADebugMacros.h"
 
 @implementation GAScriptBlockObject
 


### PR DESCRIPTION
Warning for implicit declaration of GADebugStr() function as debug
"GADebugMacros.h" header not imported
